### PR TITLE
Webmock not required for regular usage of library

### DIFF
--- a/lib/wow_community_api.rb
+++ b/lib/wow_community_api.rb
@@ -1,6 +1,5 @@
 require 'httparty'
 require 'ostruct'
-require 'webmock/rspec'
 
 require "wow_community_api/version"
 require "wow_community_api/regions"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'wow_community_api'
+require 'webmock/rspec'
 
 include WowCommunityApi
 


### PR DESCRIPTION
Looks like webmock was accidentally included in the main library as I can't find any actual usage of it except in the test spec. Moving the require into the spec helper fixes this.

If this change is incorrect, then you need to move webmock from the development requirements to normal requirements as the gem currently does not work without webmock.
